### PR TITLE
remove console logging

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -24,8 +24,6 @@ interface PluginEventExtra extends PluginEvent {
  */
 export function setupPlugin({ config, global }: Meta<UserAgentMetaInput>) {
     try {
-        console.log(`UserAgentPlugin.setupPlugin() config:`, JSON.stringify(config, null, 2))
-
         global.overrideUserAgentDetails = config.overrideUserAgentDetails === 'true'
     } catch (e: unknown) {
         throw new Error('Failed to read the configuration')
@@ -47,7 +45,6 @@ export async function processEvent(event: PluginEventExtra, { global }: Meta<Use
 
     // Extrat user agent from event properties
     const userAgent = `${event.properties.$useragent ?? event.properties['$user-agent']}`
-    console.log(`UserAgentPlugin.processEvent(): Received user agent:`, userAgent)
 
     // Remove the unnecessary $useragent or $user-agent user property
     delete event.properties.$useragent


### PR DESCRIPTION
This plugin has been generating insane amounts of logging on PostHog Cloud, multiple factors more than any other.

A nicer solution would be to add a debug flag to the config that would generate the logs. 

Hope we can get this in as I'll otherwise bake in a solution within PostHog to disable logging for this plugin.