### PR TITLE
Add ability to detect  $device and $device_type

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -101,7 +101,15 @@ describe('useragent-plugin', () => {
             utils: {} as UtilsExtension,
         })
         expect(Object.keys(processedEvent.properties)).toEqual(
-            expect.arrayContaining(['$lib', '$browser', '$browser_version', '$os', '$browser_type'])
+            expect.arrayContaining([
+                '$lib',
+                '$browser',
+                '$browser_version',
+                '$os',
+                '$device',
+                '$device_type',
+                '$browser_type',
+            ])
         )
         expect(processedEvent.properties).toStrictEqual(
             expect.objectContaining({
@@ -136,13 +144,23 @@ describe('useragent-plugin', () => {
             utils: {} as UtilsExtension,
         })
         expect(Object.keys(processedEvent.properties)).toEqual(
-            expect.arrayContaining(['$lib', '$browser', '$browser_version', '$os', '$browser_type'])
+            expect.arrayContaining([
+                '$lib',
+                '$browser',
+                '$browser_version',
+                '$os',
+                '$device',
+                '$device_type',
+                '$browser_type',
+            ])
         )
         expect(processedEvent.properties).toStrictEqual(
             expect.objectContaining({
                 $browser: 'safari',
                 $browser_version: '14.0.0',
                 $os: 'Mac OS',
+                $device: '',
+                $device_type: 'Desktop',
             })
         )
     })
@@ -182,7 +200,7 @@ describe('useragent-plugin', () => {
         })
 
         expect(Object.keys(processedEvent.properties)).toEqual(
-            expect.arrayContaining(['$browser', '$browser_version', '$os', '$browser_type'])
+            expect.arrayContaining(['$browser', '$browser_version', '$os', '$device', '$device_type', '$browser_type'])
         )
 
         console.log(processedEvent.properties)
@@ -192,6 +210,59 @@ describe('useragent-plugin', () => {
                 $browser: 'edge-chromium',
                 $browser_version: '96.0.1054',
                 $os: 'Mac OS',
+                $device: '',
+                $device_type: 'Desktop',
+            })
+        )
+    })
+
+    test('should return correct browser properties for an iPhone useragent', async () => {
+        const event = {
+            id: '017dc2cb-9fe0-0000-ceed-5ef8e328261d',
+            timestamp: '2021-12-16T10:31:04.234000+00:00',
+            event: 'check',
+            distinct_id: '91786645996505845983216505144491686624250709556909346823253562854100595129050',
+            properties: {
+                $ip: '31.164.196.102',
+                $lib: 'posthog-python',
+                $lib_version: '1.4.4',
+                $plugins_deferred: [],
+                $plugins_failed: [],
+                $plugins_succeeded: ['GeoIP (3347)', 'useragentplugin (3348)'],
+                $useragent:
+                    'Mozilla/5.0 (iPhone; CPU iPhone OS 15_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.4 Mobile/15E148 Safari/604.1',
+            },
+            elements_chain: '',
+        } as unknown as PluginEvent
+
+        const processedEvent = await processEvent(event, {
+            cache: {} as CacheExtension,
+            storage: {} as StorageExtension,
+            global: {
+                enabledPlugin: true,
+                overrideUserAgentDetails: false,
+            },
+            config: { enable: 'true', overrideUserAgentDetails: 'false' },
+            attachments: {},
+            jobs: {},
+            metrics: {},
+            geoip: {} as GeoIPExtension,
+            utils: {} as UtilsExtension,
+        })
+
+        expect(Object.keys(processedEvent.properties)).toEqual(
+            expect.arrayContaining(['$browser', '$browser_version', '$os', '$device', '$device_type', '$browser_type'])
+        )
+
+        console.log(processedEvent.properties)
+
+        expect(processedEvent.properties).toStrictEqual(
+            expect.objectContaining({
+                $browser: 'ios',
+                $browser_version: '15.4.0',
+                $os: 'iOS',
+                $device: 'iPhone',
+                $device_type: 'Mobile',
             })
         )
     })
@@ -202,6 +273,8 @@ describe('useragent-plugin', () => {
                 $browser: 'safari',
                 $browser_version: '14.0',
                 $os: 'macos',
+                $device: '',
+                $device_type: 'Desktop',
                 $useragent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:82.0) Gecko/20100101 Firefox/82.0',
                 $lib: 'posthog-node',
             },
@@ -226,6 +299,8 @@ describe('useragent-plugin', () => {
                 $browser: 'safari',
                 $browser_version: '14.0',
                 $os: 'macos',
+                $device: '',
+                $device_type: 'Desktop',
             })
         )
     })

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -56,26 +56,62 @@ export async function processEvent(event: PluginEventExtra, { global }: Meta<Use
     }
 
     const agentInfo = detect(userAgent)
+    const device = detectDevice(userAgent)
+    const deviceType = detectDeviceType(userAgent)
 
     const eventProperties = Object.keys(event.properties)
     const hasBrowserProperties = eventProperties.some((value: string) =>
-        ['$browser', '$browser_version', '$os'].includes(value)
+        ['$browser', '$browser_version', '$os', '$device', '$device_type'].includes(value)
     )
 
     if (!global.overrideUserAgentDetails && hasBrowserProperties) {
         console.warn(
-            `UserAgentPlugin.processEvent(): The event has $browser, $browser_version or $os but the option 'overrideUserAgentDetails' is not enabled.`
+            `UserAgentPlugin.processEvent(): The event has $browser, $browser_version, $os, $device, or $device_type but the option 'overrideUserAgentDetails' is not enabled.`
         )
         return event
     }
 
     // The special Posthog property names are retrieved from:
-    // https://github.com/PostHog/posthog/blob/d92e533dd557694936c469f9fb1acb5d6f759334/frontend/src/lib/components/PropertyKeyInfo.js
+    // https://github.com/PostHog/posthog/blob/master/frontend/src/lib/components/PropertyKeyInfo.tsx
     event.properties['$browser'] = agentInfo.name
     event.properties['$browser_version'] = agentInfo.version
     event.properties['$os'] = agentInfo.os
+    event.properties['$device'] = device
+    event.properties['$device_type'] = deviceType
     // Custom
     event.properties['$browser_type'] = agentInfo.type
 
     return event
+}
+
+// detectDevice and detectDeviceType from https://github.com/PostHog/posthog-js/blob/9abedce5ac877caeb09205c4b693988fc09a63ca/src/utils.js#L808-L837
+function detectDevice(userAgent) {
+    if (/Windows Phone/i.test(userAgent) || /WPDesktop/.test(userAgent)) {
+        return 'Windows Phone'
+    } else if (/iPad/.test(userAgent)) {
+        return 'iPad'
+    } else if (/iPod/.test(userAgent)) {
+        return 'iPod Touch'
+    } else if (/iPhone/.test(userAgent)) {
+        return 'iPhone'
+    } else if (/(BlackBerry|PlayBook|BB10)/i.test(userAgent)) {
+        return 'BlackBerry'
+    } else if (/Android/.test(userAgent) && !/Mobile/.test(userAgent)) {
+        return 'Android Tablet'
+    } else if (/Android/.test(userAgent)) {
+        return 'Android'
+    } else {
+        return ''
+    }
+}
+
+function detectDeviceType(userAgent) {
+    const device = detectDevice(userAgent)
+    if (device === 'iPad' || device === 'Android Tablet') {
+        return 'Tablet'
+    } else if (device) {
+        return 'Mobile'
+    } else {
+        return 'Desktop'
+    }
 }


### PR DESCRIPTION
Adds the feature to detect `$device` and $device_type` from the user agent and bind it to context. The code was copied from what the posthog js [library does](https://github.com/PostHog/posthog-js/blob/9abedce5ac877caeb09205c4b693988fc09a63ca/src/utils.js#L808-L837).