### PR TITLE
ci: add github workflows to ease publishing package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+    push:
+    pull_request:
+        branches:
+            - master
+
+jobs:
+    build:
+        strategy:
+            matrix:
+                os: [ubuntu-latest]
+                node-version: [18, 19]
+
+        runs-on: ${{ matrix.os }}
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: npm ci
+            - run: npm run build
+            - run: npm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: publish
+on:
+    push:
+        tags:
+            - 'v[0-9]+.[0-9]+.[0-9]+*'
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 18
+                  registry-url: 'https://registry.npmjs.org'
+            - run: npm ci
+            - run: npm test
+            - run: npm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Add Github workflows to allow to publish the npm package by creating a new git tag